### PR TITLE
Eventを取得するS3 Bucketを限定する

### DIFF
--- a/CFn/cloudtrail-for-s3-access-audit/notification-s3-access-using-sigv2.yaml
+++ b/CFn/cloudtrail-for-s3-access-audit/notification-s3-access-using-sigv2.yaml
@@ -91,6 +91,9 @@ Resources:
           additionalEventData:
             SignatureVersion:
               - SigV2
+          resources:
+            ARN:
+              - arn:aws:s3:::${LogTargetS3Name}
       State: ENABLED
       Targets:
         - Arn: !Ref 'SnsTopic'


### PR DESCRIPTION
TrailS3Eventで指定したbucket以外のsigV2もSQSに入ってきたので
追記のようにして限定することで解決しました
オリジナルで問題ないはずなのですが、、、すみません、なぜはか不明です